### PR TITLE
Allow user to accept site policies

### DIFF
--- a/db.php
+++ b/db.php
@@ -92,6 +92,7 @@ class readonlydriver extends nativedriver{
             'backup_courses',
             'backup_ids_temp',
             'files',
+            'tool_policy_acceptances',
             'user'
         ];
 


### PR DESCRIPTION
Added table 'tool_policy_acceptances' to list of writable tables to allow users to accept site policies in read_only mode.